### PR TITLE
[NO-ISSUE] Use containers for both CI job rather than host services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ node_js:
 
 services:
   - docker
-  - rabbitmq
-  - postgresql
-
-script: npm run test:ci
 
 notifications:
   slack:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   postgres:
     image: 'postgres:9.6.3-alpine'
     ports:
-      - '5432:5432'
+      - 5432
   rabbitmq:
     image: 'rabbitmq:3.6.10-alpine'
     ports:
-      - '5672:5672'
+      - 5672

--- a/init-environment.sh
+++ b/init-environment.sh
@@ -5,7 +5,7 @@ alias echoerr=">&2 echo"
 
 # set up trap so that script can be exited from within functions
 trap "exit 1" TERM
-export main_pid=$$
+main_pid=$$
 
 lookup_service_port() {
     service=$1

--- a/init-environment.sh
+++ b/init-environment.sh
@@ -1,0 +1,25 @@
+# Initializes environment variables necessary for running
+# tests against docker containers.
+
+alias echoerr=">&2 echo"
+
+# set up trap so that script can be exited from within functions
+trap "exit 1" TERM
+export main_pid=$$
+
+lookup_service_port() {
+    service=$1
+    port=$2
+    port_mapping_output=$(docker-compose -f docker-compose.yml port $service $port)
+    if [ $? -ne 0 ]; then
+        echoerr "$service container not running. Exiting early."
+        kill -s TERM $main_pid
+    fi
+    echo "$port_mapping_output" | sed 's/.*:\([0-9][0-9]*\)$/\1/'
+}
+
+export AMQ_PORT=$(lookup_service_port rabbitmq 5672)
+export POSTGRES_PORT=$(lookup_service_port postgres 5432)
+
+echo "AMQ_PORT: $AMQ_PORT"
+echo "POSTGRES_PORT: $POSTGRES_PORT"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "docker:stop": "docker-compose down",
     "pretest": "npm run lint",
     "test": "npm run docker:start && sleep 10 && nyc ava test/unit test/integration; npm run docker:stop",
-    "test:ci": "nyc ava test/unit test/integration",
     "test:unit": "nyc ava test/unit",
     "test:integration": "npm run docker:start && sleep 10 && nyc ava test/integration; npm run docker:stop",
     "start": "browser-refresh src/server.js",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "docker:start": "docker-compose up -d",
     "docker:stop": "docker-compose down",
     "pretest": "npm run lint",
-    "test": "npm run docker:start && sleep 10 && nyc ava test/unit test/integration; npm run docker:stop",
+    "test": "npm run docker:start && sleep 10 && . ./init-environment.sh && nyc ava test/unit test/integration; npm run docker:stop",
     "test:unit": "nyc ava test/unit",
-    "test:integration": "npm run docker:start && sleep 10 && nyc ava test/integration; npm run docker:stop",
-    "start": "browser-refresh src/server.js",
-    "cluster:start": "browser-refresh src/cluster.js"
+    "test:integration": "npm run docker:start && sleep 10 && . ./init-environment.sh && nyc ava test/integration; npm run docker:stop",
+    "start": ". ./init-environment.sh && browser-refresh src/server.js",
+    "cluster:start": ". ./init-environment.sh && browser-refresh src/cluster.js"
   },
   "repository": {
     "type": "git",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,4 +3,6 @@ const registerConfig = require('windbreaker-service-util/config')
 const Config = require('./Config')
 const config = module.exports = new Config()
 
-registerConfig(config)
+registerConfig(config, [
+  { amqUrl: `amqp://localhost:${process.env.AMQ_PORT || 5672}` }
+])


### PR DESCRIPTION
Had to make a few changes I'll mention below for anyone not familiar POSIX-only shell environments (travis uses ubuntu/dash, doesn't support all the same features/extensions of the bourne again shell).

This setup assumes a docker/localhost-only path right now. In the future, we'll need to change this up a bit for handling deployed environments.