### PR TITLE
[NO-ISSUE] [NO-ISSUE] Removed consumer message handler test

### DIFF
--- a/test/integration/consumers/consumer-test.js
+++ b/test/integration/consumers/consumer-test.js
@@ -6,48 +6,21 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 proxyquire.noPreserveCache()
 
-const { createProducer } = require('windbreaker-service-util/queue')
-
-const Event = require('windbreaker-service-util/models/events/Event')
-const EventType = require('windbreaker-service-util/models/events/EventType')
-
-const waitForEvent = require('windbreaker-service-util/test/util/waitForEvent')
-
 test.before('setup config', async () => {
   return config.load()
 })
 
 test.beforeEach('initialize consumers and producers', async (t) => {
   const sandbox = sinon.sandbox.create()
-  const githubPushSpy = sandbox.spy()
 
-  const messageHandler = proxyquire('~/src/messages', {
-    '~/src/util/getEventHandlers': () => {
-      return {
-        'github-push': githubPushSpy
-      }
-    }
-  })
-
-  const consumers = proxyquire('~/src/consumers', {
-    '~/src/messages': messageHandler
-  })
+  const consumers = proxyquire('~/src/consumers', {})
 
   const { eventConsumer, workConsumer } = await consumers.initialize()
 
-  const eventProducer = await createProducer({
-    amqUrl: config.getAmqUrl(),
-    producerOptions: {
-      queueName: config.getEventsQueueName()
-    }
-  })
-
   t.context = {
     consumers,
-    githubPushSpy,
     eventConsumer,
     workConsumer,
-    eventProducer,
     sandbox
   }
 })
@@ -55,45 +28,15 @@ test.beforeEach('initialize consumers and producers', async (t) => {
 test.afterEach('teardown test environment', async (t) => {
   const {
     consumers,
-    eventProducer,
     sandbox
   } = t.context
 
   await consumers.close()
-  await eventProducer.stop()
 
   sandbox.restore()
 })
 
-test.serial('should be able to pass messages to the correct message handlers', async (t) => {
-  const {
-    githubPushSpy,
-    eventConsumer,
-    eventProducer,
-    sandbox
-  } = t.context
-
-  const simpleConsumer = eventConsumer.getConsumer()
-
-  const event = new Event({
-    type: EventType.GITHUB_PUSH,
-    data: {
-      compare: 'some string'
-    }
-  })
-
-  const messagePromise = waitForEvent(simpleConsumer, 'message')
-
-  await eventProducer.sendMessage(event)
-  await messagePromise
-
-  // validate that github push stub was called
-  sandbox.assert.calledOnce(githubPushSpy)
-
-  t.pass()
-})
-
-test.serial('should call for each consumer to stop upon closing', async (t) => {
+test('should call for each consumer to stop upon closing', async (t) => {
   t.plan(0)
 
   const {


### PR DESCRIPTION
This test was not needed, the functionality that it tested was already being tested elsewhere.

The real reason why the test was failing is due to the recent addition of the utility function for running startup tasks before tests run. The startup tasks include the creation of event consumers, meaning the tests were stepping over each other and other consumer instances were receiving the expected messages.

We don't really need to test whether or not messages can be received from the queue here anyway. That functionality is well tested in `windbreaker-service-util`. Really this test file should be used to make sure consumers are configured correctly (more tests can be added in a separate PR).